### PR TITLE
fix: set footer to always be at bottom in Verify and Certificates tabs

### DIFF
--- a/apps/qualinova-frontend/src/app/layout.tsx
+++ b/apps/qualinova-frontend/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="flex flex-col">
+      <body className="flex flex-col min-h-screen">
         <UserProvider>
           <Header />
           <main className={`${inter.className} flex-grow`}>{children}</main>


### PR DESCRIPTION
# Pull Request Overview

## Summary
Provide a brief summary of what this PR accomplishes.

### Related Issues
- Closes #[54]

### Type of Change
Mark with an `x` all the checkboxes that apply (like `[x]`).

- [ ] Feat (A new feature)
- [x] Fix (A bug fix)
- [ ] Docs (Documentation changes)
- [ ] Style (changes that do not affect the meaning of the code: formatting, etc)
- [ ] Refactor (code changes that neither fix a bug nor add a feature)
- [ ] Test (adding missing tests or correcting existing tests)
- [ ] Build (changes that affect the build system or external dependencies)
- [ ] Chore (maintenance changes that do not fall into any of the other categories)

### Changes Made
Provide a clear and concise description of what you changed and why.

- Added min-h-screen class to body in layout.tsx
- Ensures footer stays at bottom when content is short
- Uses flexbox sticky footer pattern for responsive design
- Fixes issue in both Verify tab and Certificates tab

### Technical Notes
Include any technical details that reviewers should be aware of.

### ✅ Tests Results
Describe the tests you performed to verify your changes:

### Test Coverage
- [ ] ✅ Unit Tests
- [ ] 📨 Integration Tests
- [ ] 📟 Manual Testing

### Evidence
Provide relevant evidence of testing (screenshots, test outputs, etc.).

### Testing Notes
Include any special testing considerations or edge cases checked.

### Next Steps
Indicate actions or improvements to be taken after this PR, if applicable.