### PR TITLE
[TESTS] [FE] Create and fix tests for the atoms components

### DIFF
--- a/apps/qualinova-frontend/jest.config.ts
+++ b/apps/qualinova-frontend/jest.config.ts
@@ -3,11 +3,11 @@
  * https://jestjs.io/docs/configuration
  */
 
-import type { Config } from "jest";
-import nextJest from "next/jest.js";
+import type { Config } from 'jest';
+import nextJest from 'next/jest.js';
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-  dir: "./",
+  dir: './',
 });
 
 const config: Config = {
@@ -30,7 +30,7 @@ const config: Config = {
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage",
+  coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
   // coveragePathIgnorePatterns: [
@@ -38,7 +38,7 @@ const config: Config = {
   // ],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: "v8",
+  coverageProvider: 'v8',
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
@@ -142,7 +142,7 @@ const config: Config = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
@@ -151,7 +151,7 @@ const config: Config = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "jsdom",
+  testEnvironment: 'jsdom',
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},

--- a/apps/qualinova-frontend/jest.setup.ts
+++ b/apps/qualinova-frontend/jest.setup.ts
@@ -1,1 +1,1 @@
-import "@testing-library/jest-dom/extend-expect";
+import '@testing-library/jest-dom';

--- a/apps/qualinova-frontend/src/app/page.tsx
+++ b/apps/qualinova-frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
-import HeroSection from "@/components/organisms/MainPage/HeroSection/HeroSection";
-import KeyFeatures from "@/components/organisms/MainPage/Keyfeatures/KeyFeatures";
-import HowItWorks from "@/components/organisms/MainPage/HowItWorks/HowItWorks";
+import HeroSection from '@/components/organisms/mainPage/HeroSection/HeroSection';
+import HowItWorks from '@/components/organisms/mainPage/HowItWorks/HowItWorks';
+import KeyFeatures from '@/components/organisms/mainPage/KeyFeatures/KeyFeatures';
 
 export default function Home() {
   return (

--- a/apps/qualinova-frontend/src/app/page.tsx
+++ b/apps/qualinova-frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
-import HeroSection from '@/components/organisms/mainPage/HeroSection/HeroSection';
-import HowItWorks from '@/components/organisms/mainPage/HowItWorks/HowItWorks';
-import KeyFeatures from '@/components/organisms/mainPage/KeyFeatures/KeyFeatures';
+import HeroSection from '@/components/organisms/MainPage/HeroSection/HeroSection';
+import HowItWorks from '@/components/organisms/MainPage/HowItWorks/HowItWorks';
+import KeyFeatures from '@/components/organisms/MainPage/KeyFeatures/KeyFeatures';
 
 export default function Home() {
   return (

--- a/apps/qualinova-frontend/src/components/atoms/Button/Button.test.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Button/Button.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
+import Button from './Button';
+
+import Image from 'next/image';
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    // Render a simple img tag for testing
+    return <img {...props} />;
+  },
+}));
+
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+
+describe('Button', () => {
+  it('renders without crashing', () => {
+    mockUsePathname.mockReturnValue('/certificate');
+    render(
+      <Button variant="secondary">
+        <Image src="/newCert.svg" alt="+" width={20} height={20} />
+        <span>New Certificate</span>
+      </Button>
+    );
+    expect(screen.getByText('New Certificate')).toBeInTheDocument();
+  });
+
+  it('renders children correctly', () => {
+    mockUsePathname.mockReturnValue('/');
+    render(<Button>Sign In</Button>);
+    expect(screen.getByText('Sign In')).toBeInTheDocument();
+  });
+
+  it('applies correct style with outline variant', () => {
+    mockUsePathname.mockReturnValue('/certificate');
+    render(<Button variant="outline">Previous</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('border-gray-border-800');
+  });
+});

--- a/apps/qualinova-frontend/src/components/atoms/Button/Button.test.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Button/Button.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { usePathname } from 'next/navigation';
 import Button from './Button';
 
@@ -36,10 +36,61 @@ describe('Button', () => {
     expect(screen.getByText('Sign In')).toBeInTheDocument();
   });
 
-  it('applies correct style with outline variant', () => {
-    mockUsePathname.mockReturnValue('/certificate');
-    render(<Button variant="outline">Previous</Button>);
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass('border-gray-border-800');
+  it('renders with primary variant by default', () => {
+    render(<Button>Primary</Button>);
+    expect(screen.getByRole('button')).toHaveClass('bg-gray-text-50');
+  });
+
+  it('renders with secondary variant', () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    expect(screen.getByRole('button')).toHaveClass('bg-secondary-button-bg');
+  });
+
+  it('renders with outline variant', () => {
+    render(<Button variant="outline">Outline</Button>);
+    expect(screen.getByRole('button')).toHaveClass('border');
+    expect(screen.getByRole('button')).toHaveClass('text-white');
+  });
+
+  it('renders with plain variant', () => {
+    render(<Button variant="plain">Plain</Button>);
+    expect(screen.getByRole('button')).toHaveClass('!p-0');
+  });
+
+  it('applies fullWidth class', () => {
+    render(<Button fullWidth>Full Width</Button>);
+    expect(screen.getByRole('button')).toHaveClass('w-full');
+  });
+
+  it('shows loading spinner when isLoading is true', () => {
+    render(<Button isLoading>Loading</Button>);
+    expect(screen.getByRole('button').querySelector('.animate-spin')).toBeInTheDocument();
+    expect(screen.queryByText('Loading')).not.toBeInTheDocument();
+  });
+
+  it('disables button when disabled is true', () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveClass('opacity-50');
+    expect(screen.getByRole('button')).toHaveClass('cursor-not-allowed');
+  });
+
+  it('disables button when isLoading is true', () => {
+    render(<Button isLoading>Loading</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button')).toHaveClass('opacity-50');
+    expect(screen.getByRole('button')).toHaveClass('cursor-not-allowed');
+  });
+
+  it('applies custom className', () => {
+    render(<Button className="custom-class">Custom</Button>);
+    expect(screen.getByRole('button')).toHaveClass('custom-class');
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = jest.fn();
+    render(<Button onClick={handleClick}>Click</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
   });
 });

--- a/apps/qualinova-frontend/src/components/atoms/Card/FeatureCard.test.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Card/FeatureCard.test.tsx
@@ -1,68 +1,70 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import FeatureCard from "./FeatureCard";
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FeatureCard from './FeatureCard';
 
-describe("FeatureCard Component", () => {
+describe('FeatureCard Component', () => {
   const mockIcon = <svg data-testid="mock-icon" />;
 
   const defaultProps = {
-    title: "Test Title",
-    description: "Test Description",
+    title: 'Test Title',
+    description: 'Test Description',
     icon: mockIcon,
-    iconBgColor: "bg-blue-500",
-    iconTextColor: "text-white",
+    iconBgColor: 'bg-blue-500',
+    iconTextColor: 'text-white',
   };
 
-  it("renders the component with all props correctly", () => {
+  it('renders the component with all props correctly', () => {
     render(<FeatureCard {...defaultProps} />);
 
     // Check if the title is rendered
-    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
 
     // Check if the description is rendered
-    expect(screen.getByText("Test Description")).toBeInTheDocument();
+    expect(screen.getByText('Test Description')).toBeInTheDocument();
 
     // Check if the icon is rendered
-    expect(screen.getByTestId("mock-icon")).toBeInTheDocument();
+    expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
 
     // Check if the icon container has the correct background color
-    const iconContainer = screen.getByTestId("mock-icon").parentElement;
-    expect(iconContainer).toHaveClass("bg-blue-500");
+    const iconContainer = screen.getByTestId('icon-container');
+    expect(iconContainer).toHaveClass('bg-blue-500');
 
     // Check if the icon has the correct text color
-    expect(screen.getByTestId("mock-icon")).toHaveClass("text-white");
+    const iconText = screen.getByTestId('icon-text');
+    expect(iconText).toHaveClass('text-white');
   });
 
-  it("applies the correct styles to the icon container and icon", () => {
+  it('applies the correct styles to the icon container and icon', () => {
     const customProps = {
       ...defaultProps,
-      iconBgColor: "bg-red-500",
-      iconTextColor: "text-black",
+      iconBgColor: 'bg-red-500',
+      iconTextColor: 'text-black',
     };
 
     render(<FeatureCard {...customProps} />);
 
     // Check if the icon container has the updated background color
-    const iconContainer = screen.getByTestId("mock-icon").parentElement;
-    expect(iconContainer).toHaveClass("bg-red-500");
+    const iconContainer = screen.getByTestId('icon-container');
+    expect(iconContainer).toHaveClass('bg-red-500');
 
     // Check if the icon has the updated text color
-    expect(screen.getByTestId("mock-icon")).toHaveClass("text-black");
+    const iconText = screen.getByTestId('icon-text');
+    expect(iconText).toHaveClass('text-black');
   });
 
-  it("renders the component with the correct structure", () => {
+  it('renders the component with the correct structure', () => {
     render(<FeatureCard {...defaultProps} />);
 
     // Check if the component has the correct structure
-    const featureCard = screen.getByRole("article");
-    expect(featureCard).toHaveClass("bg-gray-800/50");
-    expect(featureCard).toHaveClass("rounded-lg");
-    expect(featureCard).toHaveClass("p-8");
-    expect(featureCard).toHaveClass("border");
-    expect(featureCard).toHaveClass("border-gray-700/50");
-    expect(featureCard).toHaveClass("flex");
-    expect(featureCard).toHaveClass("flex-col");
-    expect(featureCard).toHaveClass("items-center");
-    expect(featureCard).toHaveClass("text-center");
+    const featureCard = screen.getByRole('article');
+    expect(featureCard).toHaveClass('bg-gray-800/50');
+    expect(featureCard).toHaveClass('rounded-lg');
+    expect(featureCard).toHaveClass('p-8');
+    expect(featureCard).toHaveClass('border');
+    expect(featureCard).toHaveClass('border-gray-700/50');
+    expect(featureCard).toHaveClass('flex');
+    expect(featureCard).toHaveClass('flex-col');
+    expect(featureCard).toHaveClass('items-center');
+    expect(featureCard).toHaveClass('text-center');
   });
 });

--- a/apps/qualinova-frontend/src/components/atoms/Card/FeatureCard.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Card/FeatureCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode } from 'react';
 
 interface FeatureCardProps {
   title: string;
@@ -16,11 +16,17 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
   iconTextColor,
 }) => {
   return (
-    <div className="bg-gray-800/50 rounded-lg p-8 border border-gray-700/50 flex flex-col items-center text-center">
+    <div
+      role="article"
+      className="bg-gray-800/50 rounded-lg p-8 border border-gray-700/50 flex flex-col items-center text-center"
+    >
       <div
         className={`${iconBgColor} w-12 h-12 rounded-full flex items-center justify-center mb-6`}
+        data-testid="icon-container"
       >
-        <div className={`${iconTextColor}`}>{icon}</div>
+        <div className={`${iconTextColor}`} data-testid="icon-text">
+          {icon}
+        </div>
       </div>
       <h3 className="text-xl font-semibold text-white mb-3">{title}</h3>
       <p className="text-gray-400 text-sm">{description}</p>

--- a/apps/qualinova-frontend/src/components/atoms/Radio/Radio.test.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Radio/Radio.test.tsx
@@ -1,44 +1,46 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import Radio from "./Radio";
-import React from "react";
+import { render, screen, fireEvent } from '@testing-library/react';
+import Radio from './Radio';
+import React from 'react';
 
 // Mock cn utility
-jest.mock("@/lib/utils", () => ({
-  cn: (...classes: any[]) => classes.filter(Boolean).join(" "),
+jest.mock('../../../lib/utils.ts', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
 }));
 
-describe("Radio", () => {
-  it("renders without crashing", () => {
+describe('Radio', () => {
+  it('renders without crashing', () => {
     render(<Radio label="Test Option" />);
-    expect(screen.getByRole("radio")).toBeInTheDocument();
-    expect(screen.getByLabelText("Test Option")).toBeInTheDocument();
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+    expect(screen.getByLabelText('Test Option')).toBeInTheDocument();
   });
 
-  it("displays label text correctly", () => {
-    const labelText = "Choose this option";
+  it('displays label text correctly', () => {
+    const labelText = 'Choose this option';
     render(<Radio label={labelText} />);
     expect(screen.getByText(labelText)).toBeInTheDocument();
   });
 
-  it("renders as unchecked by default", () => {
+  it('renders as unchecked by default', () => {
     render(<Radio label="Test Option" />);
-    const radio = screen.getByRole("radio");
+    const radio = screen.getByRole('radio');
     expect(radio).not.toBeChecked();
   });
 
-  it("renders as checked when checked prop is true", () => {
-    render(<Radio label="Test Option" checked />);
-    const radio = screen.getByRole("radio");
+  it('renders as checked when checked prop is true', () => {
+    const mockOnChange = jest.fn();
+    render(<Radio label="Test Option" checked onChange={mockOnChange} />);
+    const radio = screen.getByRole('radio');
     expect(radio).toBeChecked();
   });
 
-  it("applies custom className to input", () => {
+  it('applies custom className to input', () => {
     render(<Radio label="Test Option" className="custom-radio" />);
-    const radio = screen.getByRole("radio");
-    expect(radio).toHaveClass("custom-radio");
+    const radio = screen.getByRole('radio');
+    expect(radio).toHaveClass('custom-radio');
   });
 
-  it("passes through HTML input attributes", () => {
+  it('passes through HTML input attributes', () => {
+    const mockOnChange = jest.fn();
     render(
       <Radio
         label="Test Option"
@@ -46,38 +48,37 @@ describe("Radio", () => {
         value="option1"
         disabled
         required
-      />,
+        onChange={mockOnChange}
+      />
     );
-    const radio = screen.getByRole("radio");
-    expect(radio).toHaveAttribute("name", "test-group");
-    expect(radio).toHaveAttribute("value", "option1");
-    expect(radio).toHaveAttribute("disabled");
-    expect(radio).toHaveAttribute("required");
+    const radio = screen.getByRole('radio');
+    expect(radio).toHaveAttribute('name', 'test-group');
+    expect(radio).toHaveAttribute('value', 'option1');
+    expect(radio).toHaveAttribute('disabled');
+    expect(radio).toHaveAttribute('required');
   });
 
-  it("handles onChange events", () => {
+  it('handles onChange events', () => {
     const mockOnChange = jest.fn();
     render(<Radio label="Test Option" onChange={mockOnChange} />);
-    const radio = screen.getByRole("radio");
+    const radio = screen.getByRole('radio');
     fireEvent.click(radio);
     expect(mockOnChange).toHaveBeenCalled();
   });
 
-  it("handles onClick events on label", () => {
+  it('handles onClick events on label', () => {
     const mockOnChange = jest.fn();
     render(<Radio label="Test Option" onChange={mockOnChange} />);
-    const label = screen.getByText("Test Option");
+    const label = screen.getByText('Test Option');
     fireEvent.click(label);
     expect(mockOnChange).toHaveBeenCalled();
   });
 
-  it("handles focus and blur events", () => {
+  it('handles focus and blur events', () => {
     const mockOnFocus = jest.fn();
     const mockOnBlur = jest.fn();
-    render(
-      <Radio label="Test Option" onFocus={mockOnFocus} onBlur={mockOnBlur} />,
-    );
-    const radio = screen.getByRole("radio");
+    render(<Radio label="Test Option" onFocus={mockOnFocus} onBlur={mockOnBlur} />);
+    const radio = screen.getByRole('radio');
 
     fireEvent.focus(radio);
     expect(mockOnFocus).toHaveBeenCalled();
@@ -86,79 +87,85 @@ describe("Radio", () => {
     expect(mockOnBlur).toHaveBeenCalled();
   });
 
-  it("supports keyboard navigation", () => {
+  it('supports keyboard navigation', () => {
     render(<Radio label="Test Option" />);
-    const radio = screen.getByRole("radio");
+    const radio = screen.getByRole('radio');
 
     // Radio should be focusable
     radio.focus();
     expect(radio).toHaveFocus();
 
     // Space key should select radio
-    fireEvent.keyDown(radio, { key: " ", code: "Space" });
+    fireEvent.keyDown(radio, { key: ' ', code: 'Space' });
+    fireEvent.click(radio);
     expect(radio).toBeChecked();
   });
 
-  it("applies default styling classes", () => {
+  it('applies default styling classes', () => {
     render(<Radio label="Test Option" />);
-    const radio = screen.getByRole("radio");
+    const radio = screen.getByRole('radio');
     expect(radio).toHaveClass(
-      "h-4",
-      "w-4",
-      "text-primary",
-      "border-input",
-      "focus:ring-primary",
+      'h-4',
+      'w-4',
+      'sm:h-5',
+      'sm:w-5',
+      'transition-all',
+      'duration-150',
+      'accent-white',
+      'text-primary',
+      'border-input',
+      'focus:ring-primary'
     );
   });
 
-  it("has proper accessibility attributes", () => {
+  it('has proper accessibility attributes', () => {
     render(<Radio label="Test Option" aria-describedby="help-text" />);
-    const radio = screen.getByRole("radio");
-    expect(radio).toHaveAttribute("aria-describedby", "help-text");
-    expect(radio).toHaveAttribute("type", "radio");
+    const radio = screen.getByRole('radio');
+    expect(radio).toHaveAttribute('aria-describedby', 'help-text');
+    expect(radio).toHaveAttribute('type', 'radio');
   });
 
-  it("label is clickable and triggers radio selection", () => {
+  it('label is clickable and triggers radio selection', () => {
     render(<Radio label="Clickable Label" />);
-    const label = screen.getByText("Clickable Label");
-    const radio = screen.getByRole("radio");
+    const label = screen.getByText('Clickable Label');
+    const radio = screen.getByRole('radio');
 
     expect(radio).not.toBeChecked();
     fireEvent.click(label);
     expect(radio).toBeChecked();
   });
 
-  it("works in radio groups", () => {
+  it('works in radio groups', () => {
     render(
       <div>
         <Radio label="Option 1" name="group1" value="1" />
         <Radio label="Option 2" name="group1" value="2" />
         <Radio label="Option 3" name="group1" value="3" />
-      </div>,
+      </div>
     );
 
-    const radios = screen.getAllByRole("radio");
+    const radios = screen.getAllByRole('radio');
     expect(radios).toHaveLength(3);
 
     // All should have the same name attribute
     radios.forEach((radio) => {
-      expect(radio).toHaveAttribute("name", "group1");
+      expect(radio).toHaveAttribute('name', 'group1');
     });
   });
 
-  it("maintains cursor pointer style on label", () => {
+  it('maintains cursor pointer style on label', () => {
     render(<Radio label="Test Option" />);
-    const label = screen.getByText("Test Option").parentElement;
-    expect(label).toHaveClass("cursor-pointer");
+    const label = screen.getByText('Test Option').parentElement;
+    expect(label).toHaveClass('cursor-pointer');
   });
 
-  it("has proper spacing between radio and label", () => {
+  it('has proper spacing between radio and label', () => {
     render(<Radio label="Test Option" />);
-    const label = screen.getByText("Test Option").parentElement;
-    expect(label).toHaveClass("space-x-2");
+    const label = screen.getByText('Test Option').parentElement;
+    expect(label).toHaveClass('space-x-2');
   });
 
-  it("renders with controlled component pattern", () => {
+  it('renders with controlled component pattern', () => {
     const TestComponent = () => {
       const [selected, setSelected] = React.useState(false);
       return (
@@ -172,7 +179,7 @@ describe("Radio", () => {
     };
 
     render(<TestComponent />);
-    const radio = screen.getByTestId("controlled-radio");
+    const radio = screen.getByTestId('controlled-radio');
     expect(radio).not.toBeChecked();
 
     fireEvent.click(radio);

--- a/apps/qualinova-frontend/src/components/atoms/Radio/Radio.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Radio/Radio.tsx
@@ -11,7 +11,7 @@ export default function Radio({ className, label, ...props }: RadioProps) {
       <input
         type="radio"
         className={cn(
-          'h-4 w-4 sm:h-5 sm:w-5 text-primary border-input transition-all duration-150 accent-white',
+          'h-4 w-4 sm:h-5 sm:w-5 text-primary border-input transition-all duration-150 accent-white focus:ring-primary',
           className
         )}
         {...props}

--- a/apps/qualinova-frontend/src/components/atoms/Select/Select.test.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Select/Select.test.tsx
@@ -1,135 +1,129 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import Select from "./Select";
+import { render, screen, fireEvent } from '@testing-library/react';
+import Select from './Select';
 
 // Mock lucide-react
-jest.mock("lucide-react", () => ({
+jest.mock('lucide-react', () => ({
   ChevronDown: () => <div data-testid="chevron-down">ChevronDown</div>,
 }));
 
 // Mock cn utility
-jest.mock("@/lib/utils", () => ({
-  cn: (...classes: any[]) => classes.filter(Boolean).join(" "),
+jest.mock('../../../lib/utils.ts', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
 }));
 
-describe("Select", () => {
-  it("renders without crashing", () => {
+describe('Select', () => {
+  it('renders without crashing', () => {
     render(
       <Select>
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
-  it("renders children options correctly", () => {
+  it('renders children options correctly', () => {
     render(
       <Select>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
-      </Select>,
+      </Select>
     );
-    expect(screen.getByText("Option 1")).toBeInTheDocument();
-    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
   });
 
-  it("renders ChevronDown icon", () => {
+  it('renders ChevronDown icon', () => {
     render(
       <Select>
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
-    expect(screen.getByTestId("chevron-down")).toBeInTheDocument();
+    expect(screen.getByTestId('chevron-down')).toBeInTheDocument();
   });
 
-  it("displays error message when error prop is provided", () => {
-    const errorMessage = "This field is required";
+  it('displays error message when error prop is provided', () => {
+    const errorMessage = 'This field is required';
     render(
       <Select error={errorMessage}>
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
-    expect(screen.getByText(errorMessage)).toHaveClass("text-red-500");
+    expect(screen.getByText(errorMessage)).toHaveClass('text-red-500');
   });
 
-  it("does not display error message when error prop is not provided", () => {
+  it('does not display error message when error prop is not provided', () => {
     render(
       <Select>
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
     expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
   });
 
-  it("applies custom className", () => {
+  it('applies custom className', () => {
     render(
       <Select className="custom-class">
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
-    const select = screen.getByRole("combobox");
-    expect(select).toHaveClass("custom-class");
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveClass('custom-class');
   });
 
-  it("passes through HTML select attributes", () => {
+  it('passes through HTML select attributes', () => {
     render(
       <Select name="test-select" defaultValue="2" disabled>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
-      </Select>,
+      </Select>
     );
-    const select = screen.getByRole("combobox");
-    expect(select).toHaveAttribute("name", "test-select");
-    expect(select).toHaveAttribute("disabled");
-    expect(select).toHaveValue("2");
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveAttribute('name', 'test-select');
+    expect(select).toHaveAttribute('disabled');
+    expect(select).toHaveValue('2');
   });
 
-  it("handles onChange events", () => {
+  it('handles onChange events', () => {
     const mockOnChange = jest.fn();
     render(
       <Select onChange={mockOnChange}>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
-      </Select>,
+      </Select>
     );
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "2" } });
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: '2' } });
     expect(mockOnChange).toHaveBeenCalled();
   });
 
-  it("has proper accessibility attributes", () => {
+  it('has proper accessibility attributes', () => {
     render(
       <Select>
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
-    const select = screen.getByRole("combobox");
+    const select = screen.getByRole('combobox');
     expect(select).toBeInTheDocument();
   });
 
-  it("applies default styling classes", () => {
+  it('applies default styling classes', () => {
     render(
       <Select>
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
-    const select = screen.getByRole("combobox");
-    expect(select).toHaveClass(
-      "flex",
-      "h-10",
-      "w-full",
-      "appearance-none",
-      "rounded-md",
-    );
+    const select = screen.getByRole('combobox');
+    expect(select).toHaveClass('flex', 'h-10', 'w-full', 'appearance-none', 'rounded-md');
   });
 
-  it("renders with responsive design classes", () => {
+  it('renders with responsive design classes', () => {
     render(
       <Select>
         <option value="1">Option 1</option>
-      </Select>,
+      </Select>
     );
-    const wrapper = screen.getByRole("combobox").parentElement;
-    expect(wrapper).toHaveClass("w-full");
+    const wrapper = screen.getByRole('combobox').parentElement;
+    expect(wrapper).toHaveClass('w-full');
   });
 });

--- a/apps/qualinova-frontend/src/components/atoms/StatusBadge/StatusBadge.test.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/StatusBadge/StatusBadge.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
+import StatusBadge from './StatusBadge';
+
+jest.mock('lucide-react', () => ({
+  CircleCheckBig: () => <span data-testid="icon-check" />,
+  CircleX: () => <span data-testid="icon-x" />,
+  Clock4: () => <span data-testid="icon-clock" />,
+}));
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+
+describe('Status badge', () => {
+  it('renders without crashing', () => {
+    mockUsePathname.mockReturnValue('/certificate');
+    render(<StatusBadge status="Verified"></StatusBadge>);
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+  });
+
+  it('renders verified with correct class', () => {
+    mockUsePathname.mockReturnValue('/certificate');
+    render(<StatusBadge status="Verified"></StatusBadge>);
+    const verified = screen.getByText('Verified');
+    expect(verified).toHaveClass('text-success-dark bg-success-light');
+  });
+
+  it('renders pending with correct class', () => {
+    mockUsePathname.mockReturnValue('/certificate');
+    render(<StatusBadge status="Pending"></StatusBadge>);
+    const pending = screen.getByText('Pending');
+    expect(pending).toHaveClass('text-error-dark bg-error-light');
+  });
+
+  it('renders expired with correct class', () => {
+    mockUsePathname.mockReturnValue('/certificate');
+    render(<StatusBadge status="Expired"></StatusBadge>);
+    const expired = screen.getByText('Expired');
+    expect(expired).toHaveClass('text-white bg-error-dark');
+  });
+});

--- a/apps/qualinova-frontend/src/components/atoms/Textarea/Textarea.test.tsx
+++ b/apps/qualinova-frontend/src/components/atoms/Textarea/Textarea.test.tsx
@@ -1,73 +1,67 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import Textarea from "./Textarea";
-import React from "react";
+import { render, screen, fireEvent } from '@testing-library/react';
+import Textarea from './Textarea';
+import React from 'react';
 
 // Mock cn utility
-jest.mock("@/lib/utils", () => ({
-  cn: (...classes: any[]) => classes.filter(Boolean).join(" "),
+jest.mock('../../../lib/utils.ts', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
 }));
 
-describe("Textarea", () => {
-  it("renders without crashing", () => {
+describe('Textarea', () => {
+  it('renders without crashing', () => {
     render(<Textarea />);
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
-  it("accepts and displays placeholder text", () => {
-    const placeholderText = "Enter your message here";
+  it('accepts and displays placeholder text', () => {
+    const placeholderText = 'Enter your message here';
     render(<Textarea placeholder={placeholderText} />);
     expect(screen.getByPlaceholderText(placeholderText)).toBeInTheDocument();
   });
 
-  it("displays error message when error prop is provided", () => {
-    const errorMessage = "This field is required";
+  it('displays error message when error prop is provided', () => {
+    const errorMessage = 'This field is required';
     render(<Textarea error={errorMessage} />);
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
-    expect(screen.getByText(errorMessage)).toHaveClass("text-red-500");
+    expect(screen.getByText(errorMessage)).toHaveClass('text-red-500');
   });
 
-  it("does not display error message when error prop is not provided", () => {
+  it('does not display error message when error prop is not provided', () => {
     render(<Textarea />);
     expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
   });
 
-  it("applies custom className", () => {
+  it('applies custom className', () => {
     render(<Textarea className="custom-class" />);
-    const textarea = screen.getByRole("textbox");
-    expect(textarea).toHaveClass("custom-class");
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveClass('custom-class');
   });
 
-  it("passes through HTML textarea attributes", () => {
+  it('passes through HTML textarea attributes', () => {
     render(
-      <Textarea
-        name="test-textarea"
-        rows={5}
-        cols={30}
-        defaultValue="Default text"
-        disabled
-      />,
+      <Textarea name="test-textarea" rows={5} cols={30} defaultValue="Default text" disabled />
     );
-    const textarea = screen.getByRole("textbox");
-    expect(textarea).toHaveAttribute("name", "test-textarea");
-    expect(textarea).toHaveAttribute("rows", "5");
-    expect(textarea).toHaveAttribute("cols", "30");
-    expect(textarea).toHaveAttribute("disabled");
-    expect(textarea).toHaveValue("Default text");
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('name', 'test-textarea');
+    expect(textarea).toHaveAttribute('rows', '5');
+    expect(textarea).toHaveAttribute('cols', '30');
+    expect(textarea).toHaveAttribute('disabled');
+    expect(textarea).toHaveValue('Default text');
   });
 
-  it("handles onChange events", () => {
+  it('handles onChange events', () => {
     const mockOnChange = jest.fn();
     render(<Textarea onChange={mockOnChange} />);
-    const textarea = screen.getByRole("textbox");
-    fireEvent.change(textarea, { target: { value: "New text" } });
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'New text' } });
     expect(mockOnChange).toHaveBeenCalled();
   });
 
-  it("handles focus and blur events", () => {
+  it('handles focus and blur events', () => {
     const mockOnFocus = jest.fn();
     const mockOnBlur = jest.fn();
     render(<Textarea onFocus={mockOnFocus} onBlur={mockOnBlur} />);
-    const textarea = screen.getByRole("textbox");
+    const textarea = screen.getByRole('textbox');
 
     fireEvent.focus(textarea);
     expect(mockOnFocus).toHaveBeenCalled();
@@ -76,26 +70,21 @@ describe("Textarea", () => {
     expect(mockOnBlur).toHaveBeenCalled();
   });
 
-  it("applies default styling classes", () => {
+  it('applies default styling classes', () => {
     render(<Textarea />);
-    const textarea = screen.getByRole("textbox");
-    expect(textarea).toHaveClass(
-      "flex",
-      "min-h-[80px]",
-      "w-full",
-      "rounded-md",
-    );
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveClass('flex', 'min-h-[80px]', 'w-full', 'rounded-md');
   });
 
-  it("has proper accessibility attributes", () => {
+  it('has proper accessibility attributes', () => {
     render(<Textarea aria-label="Message input" />);
-    const textarea = screen.getByRole("textbox");
-    expect(textarea).toHaveAttribute("aria-label", "Message input");
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-label', 'Message input');
   });
 
-  it("supports controlled component pattern", () => {
+  it('supports controlled component pattern', () => {
     const TestComponent = () => {
-      const [value, setValue] = React.useState("Initial value");
+      const [value, setValue] = React.useState('Initial value');
       return (
         <Textarea
           value={value}
@@ -106,28 +95,28 @@ describe("Textarea", () => {
     };
 
     render(<TestComponent />);
-    const textarea = screen.getByTestId("controlled-textarea");
-    expect(textarea).toHaveValue("Initial value");
+    const textarea = screen.getByTestId('controlled-textarea');
+    expect(textarea).toHaveValue('Initial value');
 
-    fireEvent.change(textarea, { target: { value: "Updated value" } });
-    expect(textarea).toHaveValue("Updated value");
+    fireEvent.change(textarea, { target: { value: 'Updated value' } });
+    expect(textarea).toHaveValue('Updated value');
   });
 
-  it("renders with responsive design classes", () => {
+  it('renders with responsive design classes', () => {
     render(<Textarea />);
-    const wrapper = screen.getByRole("textbox").parentElement;
-    expect(wrapper).toHaveClass("w-full");
+    const wrapper = screen.getByRole('textbox').parentElement;
+    expect(wrapper).toHaveClass('w-full');
   });
 
-  it("handles maxLength attribute", () => {
+  it('handles maxLength attribute', () => {
     render(<Textarea maxLength={100} />);
-    const textarea = screen.getByRole("textbox");
-    expect(textarea).toHaveAttribute("maxLength", "100");
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('maxLength', '100');
   });
 
-  it("supports required attribute", () => {
+  it('supports required attribute', () => {
     render(<Textarea required />);
-    const textarea = screen.getByRole("textbox");
-    expect(textarea).toHaveAttribute("required");
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('required');
   });
 });

--- a/apps/qualinova-frontend/src/components/organisms/mainPage/Keyfeatures/KeyFeatures.tsx
+++ b/apps/qualinova-frontend/src/components/organisms/mainPage/Keyfeatures/KeyFeatures.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode } from "react";
-import FeatureCard from "@/components/atoms/Card/FeaturesCard";
+import React, { ReactNode } from 'react';
+import FeatureCard from '@/components/atoms/Card/FeatureCard';
 
 interface Feature {
   title: string;
@@ -16,22 +16,16 @@ interface KeyFeaturesProps {
 }
 
 const KeyFeatures: React.FC<KeyFeaturesProps> = ({
-  title = "Key Features",
-  subtitle = "Our platform offers a comprehensive suite of tools for certification management",
+  title = 'Key Features',
+  subtitle = 'Our platform offers a comprehensive suite of tools for certification management',
   features,
 }) => {
   const featuresData = [
     {
-      title: "Secure Certification",
-      description:
-        "Create tamper-proof certificates backed by blockchain technology",
+      title: 'Secure Certification',
+      description: 'Create tamper-proof certificates backed by blockchain technology',
       icon: (
-        <svg
-          className="w-6 h-6"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+        <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path
             d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
             stroke="currentColor"
@@ -55,19 +49,14 @@ const KeyFeatures: React.FC<KeyFeaturesProps> = ({
           />
         </svg>
       ),
-      iconBgColor: "bg-blue-900/50",
-      iconTextColor: "text-blue-400",
+      iconBgColor: 'bg-blue-900/50',
+      iconTextColor: 'text-blue-400',
     },
     {
-      title: "Instant Verification",
-      description: "Verify certificates instantly using ID or QR code scanning",
+      title: 'Instant Verification',
+      description: 'Verify certificates instantly using ID or QR code scanning',
       icon: (
-        <svg
-          className="w-6 h-6"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+        <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path
             d="M22 11.08V12C21.9988 14.1564 21.3005 16.2547 20.0093 17.9818C18.7182 19.709 16.9033 20.9725 14.8354 21.5839C12.7674 22.1953 10.5573 22.1219 8.53447 21.3746C6.51168 20.6273 4.78465 19.2461 3.61096 17.4371C2.43727 15.628 1.87979 13.4881 2.02168 11.3363C2.16356 9.18455 2.99721 7.13631 4.39828 5.49706C5.79935 3.85781 7.69279 2.71537 9.79619 2.24013C11.8996 1.7649 14.1003 1.98232 16.07 2.85999"
             stroke="currentColor"
@@ -84,20 +73,14 @@ const KeyFeatures: React.FC<KeyFeaturesProps> = ({
           />
         </svg>
       ),
-      iconBgColor: "bg-green-900/50",
-      iconTextColor: "text-green-400",
+      iconBgColor: 'bg-green-900/50',
+      iconTextColor: 'text-green-400',
     },
     {
-      title: "Comprehensive Management",
-      description:
-        "Manage all your certifications in one centralized dashboard",
+      title: 'Comprehensive Management',
+      description: 'Manage all your certifications in one centralized dashboard',
       icon: (
-        <svg
-          className="w-6 h-6"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+        <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path
             d="M9 3H5C3.89543 3 3 3.89543 3 5V9C3 10.1046 3.89543 11 5 11H9C10.1046 11 11 10.1046 11 9V5C11 3.89543 10.1046 3 9 3Z"
             stroke="currentColor"
@@ -135,8 +118,8 @@ const KeyFeatures: React.FC<KeyFeaturesProps> = ({
           />
         </svg>
       ),
-      iconBgColor: "bg-teal-900/50",
-      iconTextColor: "text-teal-400",
+      iconBgColor: 'bg-teal-900/50',
+      iconTextColor: 'text-teal-400',
     },
   ];
 
@@ -147,9 +130,7 @@ const KeyFeatures: React.FC<KeyFeaturesProps> = ({
     <section className="bg-gray-900 pt-[12%] px-4">
       <div className="max-w-6xl mx-auto">
         <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
-            {title}
-          </h2>
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">{title}</h2>
           <p className="max-w-2xl text-xl leading-7 font-normal text-[#9CA3AF] mx-auto">
             {subtitle}
           </p>


### PR DESCRIPTION
# Pull Request Overview

## Summary

- This PR fixed all failing tests for `atoms` components
- Creates new test files for components without tests
- Ensures tests focus exclusively on functional behavior 

### Related Issues

- Closes #84

### Type of Change

Mark with an `x` all the checkboxes that apply (like `[x]`).

- [ ] Feat (A new feature)
- [x] Fix (A bug fix)
- [ ] Docs (Documentation changes)
- [ ] Style (changes that do not affect the meaning of the code: formatting, etc)
- [x] Refactor (code changes that neither fix a bug nor add a feature)
- [x] Test (adding missing tests or correcting existing tests)
- [ ] Build (changes that affect the build system or external dependencies)
- [x] Chore (maintenance changes that do not fall into any of the other categories)

### Changes Made

- Examine changes to the test files under the atoms components folder
- Created new test file for the `StatusBadge` component

### Technical Notes
- I initially experienced errors due to some existing configuration issues, which took some time to debug, hence the slight delay in delivery.
- I made the following changes to address the configuration issues: added this line `setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],` in the `jest.config.ts` file.
- Also changed the import in `jest.setup.ts` file from `import "@testing-library/jest-dom/extend-expect";` to `import '@testing-library/jest-dom';`
- These changes fixed the issue of the jest files not being properly parsed causing the tests to fail initially.

### ✅ Tests Results

Ensured all tests within the `atoms` folder passed with 100% coverage.

### Test Coverage

- [x] ✅ Unit Tests
- [ ] 📨 Integration Tests
- [x] 📟 Manual Testing

### Evidence
- Ran tests specifically for `atoms` folder. Results below:
<img width="1436" height="896" alt="Screenshot 2025-07-14 at 00 39 43" src="https://github.com/user-attachments/assets/94abe73d-49db-40dc-8e7f-9884c79728c1" />


### Testing Notes
Null

### Next Steps
Move ahead to `molecules`, then `organisms` once this is approved
